### PR TITLE
renderLicenseSection function has been added

### DIFF
--- a/Sample_README.md
+++ b/Sample_README.md
@@ -1,38 +1,40 @@
-# New Project
+# License link Section
 
   [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
   ## Description
 
-  al;skdjf
+  a;sdlkfj
 
   ## Table of Contents 
 
-  No thank you 
+  a;sldkfj 
     
   ## Installation
 
-  al;ksdjf
+  aldkfj
 
   ## Usage
 
-  Use it
+  a;ldkfj
 
   ## License
 
+  This application is covered under the license linked below.  For further information regarding the license and its terms, please consult the official licensing documentation using the provided link.
+  
   [License: MIT](https://opensource.org/licenses/MIT)
 
   ## Contributions
 
-  al;skdjf
+  asdf
 
   ## Tests
 
-  none
+  asdf
 
   ## Questions for the Developer?
 
   Please contact me at:  
-  GitHub: alsd;kjd  
-  Email: a;sldfj
+  GitHub: asdf  
+  Email: asdf
   

--- a/index.js
+++ b/index.js
@@ -31,9 +31,15 @@ const questionPrompts = [
         message: "Please describe how this application should be used.",
     },
     {
-        type: 'input',
+        type: 'list',
         name: 'license',
-        message: "Which license was used?",
+        message: "Please select the license used for this application.",
+        choices: [
+            {name: 'ISC', value: 'ISC'},
+            {name: 'PDDL', value: 'PDDL'},
+            {name: 'MIT', value: 'MIT'},
+            {name: 'ODbl', value: 'ODbl'},
+         ],
     },
     {
         type: 'input',
@@ -44,11 +50,6 @@ const questionPrompts = [
         type: 'input',
         name: 'tests',
         message: "If tests were run on the application, what were they and how should they be conducted?",
-    },
-        {
-        type: 'input',
-        name: 'questions',
-        message: "Questions for the developer?",
     },
     {
         type: 'input',
@@ -76,7 +77,7 @@ init = async () => {
   const answers = await inquirer
     .prompt(questionPrompts)
 
-    // console.log(answers);
+    console.log(answers);
 
     writeToFile('Sample_README.md', generateMarkdown(answers));
 }

--- a/utils/generateMarkdown.js
+++ b/utils/generateMarkdown.js
@@ -10,6 +10,8 @@ renderLicenseBadge = (license) => {
 
 // TODO: Create a function that returns the license link
 // If there is no license, return an empty string
+
+
 renderLicenseLink = (license) => {
   if (!license) {
     return ''
@@ -21,7 +23,9 @@ renderLicenseLink = (license) => {
 // TODO: Create a function that returns the license section of README
 // If there is no license, return an empty string
 renderLicenseSection = (license) => {
-
+  return `This application is covered under the license linked below.  For further information regarding the license and its terms, please consult the official licensing documentation using the provided link.
+  
+  ${renderLicenseLink(license)}`
 }
 
 // TODO: Create a function to generate markdown for README
@@ -66,7 +70,7 @@ generateMarkdown = ({ title, description, tableOfContents, installation, use, li
 
   ## License
 
-  ${renderLicenseLink(license)}
+  ${renderLicenseSection(license)}
 
   ## Contributions
 
@@ -78,7 +82,8 @@ generateMarkdown = ({ title, description, tableOfContents, installation, use, li
 
   ## Questions for the Developer?
 
-  Please contact me at:  
+  If you have any questions, please contact me using the information provided below:  
+    
   GitHub: ${username}  
   Email: ${email}
   `


### PR DESCRIPTION
The renderLicenseSection function has been updated to include text and call the renderLicenseLink function.  This populates a description in the license section of the README. with a link to the open source licensing information.  The renderLicenseLink function is called within the generateMarkdown function.